### PR TITLE
Use :w instead of :safe option

### DIFF
--- a/lib/database.rb
+++ b/lib/database.rb
@@ -17,6 +17,9 @@ end
 
 Mongo::Model.default_database_name = db_name
 
+Mongo.defaults[:w] = true
+Mongo.defaults.delete(:safe)
+
 Mongo.class_eval do
   class << self
     def db(name)


### PR DESCRIPTION
Jag fick följande fel med appen i fredags när jag försökte spara en ny gäst: 
```
App 24500 stderr: [DEPRECATED] The 'safe' write concern option has been deprecated in favor of 'w'.
App 24500 stderr: Mongo::OperationFailure - Database command 'insert' failed: Unknown option to insert command: w:
```

Jag gissar att det beror på att jag lokalt kör en relativt ny version av mongo `3.4.5` lokalt. Löste det iaf genom att lägga till det här. Skulle egentligen bara villa köra det om versionen är > 3.0 men har inte listat ut hur man gör det ännu.